### PR TITLE
Fix schedulesBuilder.js not replacing the trips when GTFS is corrected.

### DIFF
--- a/daemon/modules/schedulesBuilder.js
+++ b/daemon/modules/schedulesBuilder.js
@@ -350,7 +350,7 @@ module.exports = {
 
       // Save route to MongoDB
       try {
-        await GTFSAPIDB.Route.findOneAndUpdate({ route_id: formattedRoute.route_id }, formattedRoute, { upsert: true });
+        await GTFSAPIDB.Route.findOneAndReplace({ route_id: formattedRoute.route_id }, formattedRoute, { upsert: true });
       } catch (error) {
         console.log('ERROR UPDATING DOCUMENT IN MONGODB', error);
       }


### PR DESCRIPTION
Fixes the lingering trips that remain in objects even when the GTFS is corrected to remove them.
May also make the database objects smaller and improve performance.