### PR TITLE
Reducing Docker image sizes through cache cleaning upon installs

### DIFF
--- a/parse-datasets/Dockerfile
+++ b/parse-datasets/Dockerfile
@@ -1,16 +1,16 @@
 FROM node:alpine
 
 # Install git
-RUN apk update && \
-    apk upgrade && \
-    apk add git
+RUN apk add --update --no-cache \
+        git
 
 # Create app directory
 WORKDIR /app
 
 # Copy package.json and install app dependencies
 COPY package.json ./
-RUN npm --omit=dev install
+RUN npm --omit=dev install \
+    && npm cache clean --force
 
 # Copy the rest of the repo
 COPY . .

--- a/parse-network/Dockerfile
+++ b/parse-network/Dockerfile
@@ -1,12 +1,18 @@
 FROM node:alpine
 
+# Create app directory
 WORKDIR /app
 
+# Copy package.json and install app dependencies
 COPY package.json ./
-RUN npm install
+RUN npm install \
+    && npm cache clean --force
 
+# Copy the rest of the repo
 COPY . .
 
+# Run build script from package.json
 RUN ["npm", "run", "build"]
 
+# Start the program
 CMD ["node", "build/index.js"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,10 +1,15 @@
 FROM node:alpine
 
+# Create app directory
 WORKDIR /app
 
+# Copy package.json and install app dependencies
 COPY package.json ./
-RUN npm --omit=dev install
+RUN npm --omit=dev install \
+    && npm cache clean --force
 
+# Copy the rest of the repo
 COPY . .
 
+# Start the program
 CMD ["node", "index.js"]

--- a/switch/Dockerfile
+++ b/switch/Dockerfile
@@ -1,10 +1,15 @@
 FROM node:alpine
 
+# Create app directory
 WORKDIR /app
 
+# Copy package.json and install app dependencies
 COPY package.json ./
-RUN npm --omit=dev install
+RUN npm --omit=dev install \
+    && npm cache clean --force
 
+# Copy the rest of the repo
 COPY . .
 
+# Start the program
 CMD ["node", "index.js"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -1,10 +1,15 @@
 FROM node:alpine
 
+# Create app directory
 WORKDIR /app
 
+# Copy package.json and install app dependencies
 COPY package.json ./
-RUN npm --omit=dev install
+RUN npm --omit=dev install \
+    && npm cache clean --force
 
+# Copy the rest of the repo
 COPY . .
 
+# Start the program
 CMD ["node", "index.js"]


### PR DESCRIPTION
## Description

### Improvements
- Reduce image size by cleaning cache upon installs from _npm_ and _apk_ with `npm cache clean --force` and the `--no-cache` option respectively. Since builds use Docker image cache, the NPM/APK cache is not needed.
- Remove usage of `apk upgrade`.
    - I don't believe there's a need to upgrade all OS packages since you're already using the **latest** _alpine_ image. The provider of the base image should be the one responsible to choose the version of the packages used inside the base (or update to the latest), while you're mostly responsible for the ones you need.
- Add missing comments to Dockerfiles.

## How Has This Been Tested?
Locally through Docker builds. Results below.
<p align="center">
  <img src="https://github.com/carrismetropolitana/api/assets/47757441/8b94a506-c614-4104-854b-b996a75dd0c3" width="800">
</p>