### PR TITLE
Update packages, add send alert notifications functionality

### DIFF
--- a/sync-alerts/index.ts
+++ b/sync-alerts/index.ts
@@ -1,6 +1,7 @@
 /* * */
 
 import SERVERDB from '@/services/SERVERDB.js';
+import * as firebase from 'firebase-admin';
 
 import start from './start.js';
 
@@ -14,6 +15,10 @@ const RUN_INTERVAL = 30000; // 30 seconds
 	//
 
 	await SERVERDB.connect();
+
+	firebase.initializeApp({
+		credential: firebase.credential.cert(process.env.FIREBASE_SERVICE_ACCOUNT_PATH),
+	});
 
 	const runOnInterval = async () => {
 		await start();

--- a/sync-alerts/package.json
+++ b/sync-alerts/package.json
@@ -15,6 +15,7 @@
     "@helperkits/logger": "20240703.1726.24",
     "@helperkits/timer": "20240627.34.23",
     "dotenv": "16.4.5",
+    "firebase-admin": "^12.4.0",
     "redis": "4.7.0"
   },
   "devDependencies": {

--- a/sync-alerts/package.json
+++ b/sync-alerts/package.json
@@ -18,9 +18,9 @@
     "redis": "4.7.0"
   },
   "devDependencies": {
-    "@carrismetropolitana/eslint": "20240722.1548.55",
-    "@types/node": "22.1.0",
+    "@carrismetropolitana/eslint": "20240911.1104.10",
+    "@types/node": "22.5.4",
     "resolve-tspaths": "0.8.19",
-    "typescript": "5.5.4"
+    "typescript": "5.6.2"
   }
 }

--- a/sync-alerts/start.ts
+++ b/sync-alerts/start.ts
@@ -4,6 +4,7 @@ import SERVERDB from '@/services/SERVERDB.js';
 import parseAlertV2 from '@/services/parseAlertV2.js';
 import LOGGER from '@helperkits/logger';
 import TIMETRACKER from '@helperkits/timer';
+import crypto from 'node:crypto';
 
 /* * */
 
@@ -25,16 +26,57 @@ export default async () => {
 	LOGGER.info(`Fetched Alerts feed from the backoffice (${backofficeTimer.get()})`);
 
 	//
-	// Prepare the alerts data in JSON and Protobuf formats
+	// Prepare the alerts data in Protobuf format
 
-	const saveTimer = new TIMETRACKER();
-
-	const allAlertsArray = alertsFeedData?.entity.map(item => parseAlertV2(item));
-	await SERVERDB.client.set(`v2/network/alerts/json`, JSON.stringify(allAlertsArray));
+	const protobufTimer = new TIMETRACKER();
 
 	await SERVERDB.client.set(`v2/network/alerts/protobuf`, JSON.stringify(alertsFeedData));
 
-	LOGGER.info(`Saved ${allAlertsArray.length} Alerts to ServerDB (${saveTimer.get()})`);
+	LOGGER.info(`Saved Protobuf Alerts to ServerDB (${protobufTimer.get()})`);
+
+	//
+	// Prepare the alerts data in JSON format
+
+	const jsonTimer = new TIMETRACKER();
+
+	const allAlertsParsedV2 = alertsFeedData?.entity.map(item => parseAlertV2(item));
+
+	await SERVERDB.client.set(`v2/network/alerts/json`, JSON.stringify(allAlertsParsedV2));
+
+	LOGGER.info(`Saved ${allAlertsParsedV2.length} JSON Alerts to ServerDB (${jsonTimer.get()})`);
+
+	//
+	// Send notifications for new alerts
+
+	const notificationsTimer = new TIMETRACKER();
+
+	const allSentNotificationsTxt = await SERVERDB.client.get(`v2/network/alerts/sent_notifications`);
+	const allSentNotifications = await JSON.parse(allSentNotificationsTxt);
+
+	const hashFunction = crypto.createHash('sha1');
+	const allAlertsParsedV2Hashes = allAlertsParsedV2.map(alertData => ({
+		alert: alertData,
+		hash: hashFunction.update(JSON.stringify(alertData)).digest('hex'),
+	}));
+
+	// Send the notifications
+
+	let sentNotificationCounter = 0;
+
+	for (const alertItem of allAlertsParsedV2Hashes) {
+		if (!allSentNotifications.includes(alertItem.hash)) {
+			// sendNotification(alertItem.alert);
+			sentNotificationCounter++;
+			allSentNotifications.push(alertItem.hash);
+			LOGGER.success(`Sent notification for alert: ${alertItem.alert.alert_id}`);
+		}
+	}
+
+	await SERVERDB.client.set(`v2/network/alerts/sent_notifications`, JSON.stringify(allSentNotifications));
+
+	LOGGER.info(`Sent ${sentNotificationCounter} Notifications (${notificationsTimer.get()})`);
+
+	//
 
 	LOGGER.terminate(`Done with this iteration (${globalTimer.get()})`);
 

--- a/sync-alerts/tsconfig.json
+++ b/sync-alerts/tsconfig.json
@@ -6,7 +6,8 @@
 		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"paths": {
-			"@/services/*": ["services/*"]
+			"@/services/*": ["services/*"],
+			"@/types/*": ["types/*"]
 		},
 		"allowJs": true,
 		"outDir": "dist",

--- a/sync-alerts/types/alerts.types.ts
+++ b/sync-alerts/types/alerts.types.ts
@@ -1,0 +1,85 @@
+/* * */
+
+import { EntitySelector, TimeRange, TranslatedImage, TranslatedString } from '@/types/gtfsrt.types.js';
+
+/* * */
+
+export enum AlertCause {
+	ACCIDENT = 'ACCIDENT',
+	CONSTRUCTION = 'CONSTRUCTION',
+	DEMONSTRATION = 'DEMONSTRATION',
+	HOLIDAY = 'HOLIDAY',
+	MAINTENANCE = 'MAINTENANCE',
+	MEDICAL_EMERGENCY = 'MEDICAL_EMERGENCY',
+	OTHER_CAUSE = 'OTHER_CAUSE',
+	POLICE_ACTIVITY = 'POLICE_ACTIVITY',
+	STRIKE = 'STRIKE',
+	TECHNICAL_PROBLEM = 'TECHNICAL_PROBLEM',
+	UNKNOWN_CAUSE = 'UNKNOWN_CAUSE',
+	WEATHER = 'WEATHER',
+}
+
+export enum AlertEffect {
+	ACCESSIBILITY_ISSUE = 'ACCESSIBILITY_ISSUE',
+	ADDITIONAL_SERVICE = 'ADDITIONAL_SERVICE',
+	DETOUR = 'DETOUR',
+	MODIFIED_SERVICE = 'MODIFIED_SERVICE',
+	NO_EFFECT = 'NO_EFFECT',
+	NO_SERVICE = 'NO_SERVICE',
+	OTHER_EFFECT = 'OTHER_EFFECT',
+	REDUCED_SERVICE = 'REDUCED_SERVICE',
+	SIGNIFICANT_DELAYS = 'SIGNIFICANT_DELAYS',
+	STOP_MOVED = 'STOP_MOVED',
+	UNKNOWN_EFFECT = 'UNKNOWN_EFFECT',
+}
+
+/* * */
+
+/**
+ * An Alert is the JSON equivalent of a GTFS-RT Service Alert message.
+ * Please use a SimplifiedAlert as many convenience operations are already correctly applied.
+ */
+export interface Alert {
+	_id: string
+	activePeriod: TimeRange[]
+	cause: AlertCause
+	descriptionText: TranslatedString
+	effect: AlertEffect
+	headerText: TranslatedString
+	image: TranslatedImage
+	informedEntity: EntitySelector[]
+	url: TranslatedString
+}
+
+/* * */
+
+/**
+ * A Simplified Alert is the same as an Alert, but with the following differences:
+ * - The description is a string instead of a TranslatedString
+ * - The image URL is a string instead of a TranslatedImage
+ * - The URL is a string instead of a TranslatedString
+ * - The start_date and end_date are Date objects instead of TimeRange objects
+ * - All fields with translatable content are returned in the current app locale
+ */
+export interface SimplifiedAlert {
+	alert_id: string
+	cause: AlertCause
+	description: string
+	effect: AlertEffect
+	end_date: Date
+	image_url: null | string
+	informed_entity: EntitySelector[]
+	locale: string
+	start_date: Date
+	title: string
+	url: null | string
+}
+
+/* * */
+
+export interface AlertGroupByDate {
+	items: Alert[]
+	label?: string
+	title: string
+	value: string
+}

--- a/sync-alerts/types/gtfsrt.types.ts
+++ b/sync-alerts/types/gtfsrt.types.ts
@@ -1,0 +1,73 @@
+/* * */
+
+export interface FeedHeader {
+	gtfsRealtimeVersion: '2.0'
+	incrementality: 'FULL_DATASET'
+	timestamp: number
+}
+
+/* * */
+
+export interface TranslatedString {
+	translation: Translation[]
+}
+
+interface Translation {
+	language: string
+	text: string
+}
+
+/* * */
+
+export interface TranslatedImage {
+	localizedImage: LocalizedImage[]
+}
+
+interface LocalizedImage {
+	language: string
+	mediaType: string
+	url: string
+}
+
+/* * */
+
+export interface TimeRange {
+
+	/*
+	 * POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC). If start or end is missing,
+	 * the interval starts at minus or plus infinity. If a TimeRange is provided, either start or end must
+	 * be provided - both fields cannot be empty.
+	 *
+	 * Here, it is expected that a TimeRange object will always be provided with a start value.
+	 *
+	 * More info: https://gtfs.org/realtime/reference/#message-timerange
+	 *
+	 */
+
+	end?: number
+	start: number
+}
+
+/* * */
+
+export interface EntitySelector {
+
+	/*
+	 * A selector for an entity in a GTFS feed. The values of the fields should correspond to the appropriate fields in the GTFS feed.
+	 * At least one specifier must be given. If several are given, they should be interpreted as being joined by the logical AND operator.
+	 * Additionally, the combination of specifiers must match the corresponding information in the GTFS feed.
+	 * In other words, in order for an alert to apply to an entity in GTFS it must match all of the provided EntitySelector fields.
+	 * For example, an EntitySelector that includes the fields route_id: "5" and route_type: "3" applies only
+	 * to the route_id: "5" bus - it does not apply to any other routes of route_type: "3". If a producer wants an alert
+	 * to apply to route_id: "5" as well as route_type: "3", it should provide two separate EntitySelectors,
+	 * one referencing route_id: "5" and another referencing route_type: "3".
+	 *
+	 * More info: https://gtfs.org/realtime/reference/#message-entityselector
+	 *
+	 */
+
+	agencyId?: string
+	routeId?: string
+	stopId?: string
+	tripId?: string
+}


### PR DESCRIPTION
### Please ensure the following before merging:
- [x] Is the branch name the Linear issue code?

### Description
Added extra step to send notification to Firebase for each new alert hash.

### Changelog
- **Send notification to firebase from `sync-alerts`:** For each alert, hash its contents. For each unknown hash send a notification to Firebase and save the hash back to REDIS.