### PR TITLE
Added Complaints metrics data, endpoints and sync task

### DIFF
--- a/apps/server/src/endpoints/metrics/metrics.endpoint.ts
+++ b/apps/server/src/endpoints/metrics/metrics.endpoint.ts
@@ -110,3 +110,12 @@ FASTIFY.GET('/metrics/videowall/vkm', async (_, reply) => {
 		.header('cache-control', 'public, max-age=60')
 		.send(allItemsTxt);
 });
+
+FASTIFY.GET('/metrics/complaints', async (_, reply) => {
+	const allItemsTxt = await SERVERDB.get(SERVERDB_KEYS.METRICS.COMPLAINTS);
+	if (!allItemsTxt) return reply.code(404).send([]);
+	return reply
+		.code(200)
+		.header('cache-control', 'public, max-age=300')
+		.send(allItemsTxt);
+});

--- a/apps/sync-metrics/src/index.ts
+++ b/apps/sync-metrics/src/index.ts
@@ -6,6 +6,7 @@ import 'dotenv/config';
 
 /* * */
 
+import { complaintsMetrics } from '@/tasks/complaints-metrics.js';
 import { demandMetricsByAgencyDay } from '@/tasks/demand-metrics-by-agency-day.js';
 import { demandMetricsByAgencyMonth } from '@/tasks/demand-metrics-by-agency-month.js';
 import { demandMetricsByAgencyYear } from '@/tasks/demand-metrics-by-agency-year.js';
@@ -39,7 +40,7 @@ const RUN_INTERVAL = 60000; // 1 minute
 
 		//
 		// Run on all iterations
-
+		await complaintsMetrics();
 		await videowallDelays();
 		await videowallEmptyRides();
 		await videowallSla();

--- a/apps/sync-metrics/src/tasks/complaints-metrics.ts
+++ b/apps/sync-metrics/src/tasks/complaints-metrics.ts
@@ -1,0 +1,83 @@
+/* * */
+import type { ComplaintsMetadataSource } from '@/types/sources.ts';
+
+import { SERVERDB } from '@carrismetropolitana/api-services';
+import { SERVERDB_KEYS } from '@carrismetropolitana/api-settings';
+import { Complaints } from '@carrismetropolitana/api-types/metrics';
+import { sortCollator } from '@carrismetropolitana/api-utils';
+import LOGGER from '@helperkits/logger';
+import TIMETRACKER from '@helperkits/timer';
+import { DateTime } from 'luxon';
+import Papa from 'papaparse';
+
+/* * */
+
+const DATASET_FILE_URL = 'https://raw.githubusercontent.com/carrismetropolitana/datasets/refs/heads/latest/complaints/complaints.csv';
+
+/* * */
+
+export const complaintsMetrics = async () => {
+	//
+
+	LOGGER.title(`SYNC METADATA`);
+	const globalTimer = new TIMETRACKER();
+	LOGGER.title(`Starting sync of ${SERVERDB_KEYS.METRICS.COMPLAINTS}...`);
+	//
+	// Download and parse the data file
+
+	LOGGER.info(`Downloading data file...`);
+
+	const downloadedCsvFile = await fetch(DATASET_FILE_URL);
+	const downloadedCsvText = await downloadedCsvFile.text();
+	const allItemsCsv = Papa.parse<ComplaintsMetadataSource>(downloadedCsvText, { header: true });
+
+	LOGGER.info(`Downloading existing complaints...`);
+
+	const existingComplaintsTxt = await SERVERDB.get(SERVERDB_KEYS.METRICS.COMPLAINTS);
+	const existingComplaintsData: Complaints[] = JSON.parse(existingComplaintsTxt);
+
+	const allComplaintsMap = new Map<string, Complaints>();
+	existingComplaintsData?.forEach(complaint => allComplaintsMap.set(complaint._id.toString(), complaint));
+
+	//
+	// For each item, update its entry in the database
+
+	LOGGER.info(`Updating items...`);
+
+	let updatedItemsCounter = 0;
+	const allItemsData: Complaints[] = [];
+
+	for (const itemCsv of allItemsCsv.data) {
+		//
+		const existingItemData = allComplaintsMap.get(`${itemCsv._id}}`);
+		//
+		const parsedItemMetadata: Complaints = {
+			_id: itemCsv._id,
+			complaints: Number(itemCsv.complaints),
+			email: Number(itemCsv.email),
+			filter_value: itemCsv.filter_value,
+			info_requests: Number(itemCsv.info_requests),
+			other: Number(itemCsv.other),
+			phone: Number(itemCsv.phone),
+			total: Number(itemCsv.total),
+			type: itemCsv.type,
+		};
+		//
+		const parsedItemData = existingItemData?.type ?? 0 > DateTime.now().minus({ seconds: 90 }).toUnixInteger() ? { ...existingItemData, ...parsedItemMetadata } : parsedItemMetadata;
+		//
+		allItemsData.push(parsedItemData);
+		//
+		updatedItemsCounter++;
+		//
+	}
+
+	//
+	// Save items to the database
+
+	allItemsData.sort((a, b) => sortCollator.compare(a._id.toString(), b._id.toString()));
+	await SERVERDB.set(SERVERDB_KEYS.METRICS.COMPLAINTS, JSON.stringify(allItemsData));
+
+	LOGGER.success(`Done updating ${updatedItemsCounter} items to ${SERVERDB_KEYS.METRICS.COMPLAINTS} (${globalTimer.get()}).`);
+
+	//
+};

--- a/apps/sync-metrics/src/types/sources.ts
+++ b/apps/sync-metrics/src/types/sources.ts
@@ -1,0 +1,12 @@
+export interface ComplaintsMetadataSource {
+	_id: string
+	complaints: number
+	email: number
+	filter_value: string
+	info_requests: number
+	other: number
+	phone: number
+	total: number
+	type: string
+
+}

--- a/packages/settings/src/constants.ts
+++ b/packages/settings/src/constants.ts
@@ -19,6 +19,7 @@ export const SERVERDB_KEYS = Object.freeze({
 		REGIONS: 'locations:regions',
 	},
 	METRICS: {
+		COMPLAINTS: 'metrics:complaints',
 		DEMAND: {
 			BY_AGENCY: {
 				DAY: 'metrics:demand:agency:day',

--- a/packages/types/src/api/metrics.ts
+++ b/packages/types/src/api/metrics.ts
@@ -61,3 +61,17 @@ interface ByDay {
 	day: string
 	qty: number
 }
+
+/* * */
+
+export interface Complaints {
+	_id: string
+	complaints: number
+	email: number
+	filter_value: string
+	info_requests: number
+	other: number
+	phone: number
+	total: number
+	type: string
+}


### PR DESCRIPTION
This pull request introduces a new feature to handle complaints metrics, including fetching, processing, and storing the data. It adds a new endpoint, integrates the new metrics into the existing sync process, and defines the necessary types and constants.

### New Feature: Complaints Metrics

* **New Endpoint:**
  - Added a new GET endpoint `/metrics/complaints` to fetch complaints metrics from the server database. (`apps/server/src/endpoints/metrics/metrics.endpoint.ts`)

* **Integration in Sync Process:**
  - Incorporated `complaintsMetrics` task into the sync process to run at regular intervals. (`apps/sync-metrics/src/index.ts`) [[1]](diffhunk://#diff-c28dbb2cf9cc1625666148de768c06167a18f3a4a2ba265ce69325619e423a37R9) [[2]](diffhunk://#diff-c28dbb2cf9cc1625666148de768c06167a18f3a4a2ba265ce69325619e423a37L42-R43)

* **Complaints Metrics Task:**
  - Created `complaintsMetrics` task to download, parse, and update complaints data in the server database. (`apps/sync-metrics/src/tasks/complaints-metrics.ts`)

* **Type Definitions:**
  - Defined `ComplaintsMetadataSource` interface for parsing complaints data. (`apps/sync-metrics/src/types/sources.ts`)
  - Added `Complaints` interface for complaints data structure. (`packages/types/src/api/metrics.ts`)

* **Constants Update:**
  - Added `COMPLAINTS` key to `SERVERDB_KEYS` for storing complaints metrics. (`packages/settings/src/constants.ts`)