### PR TITLE
Implement stopId and stopSequence to PIP Estimates endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ Sending "000000" as a stop ID will result in a testing/placeholder response bein
         "operatorId": "", // Deprecated
         "patternId": "1607_0_2",
         "stopHeadsign": "Oeiras Parque",
-        "stopId": "", // Deprecated
+        "stopId": "121270",
+        "stopSequence": 30,
         "timetabledArrivalTime": "18:39:00",
         "timetabledDepartureTime": "18:39:00"
     },
@@ -1137,5 +1138,6 @@ Returns a list of PIPs (Passenger Information Screens) in the Lisbon metropolita
 # Contributing
 
 If you'd like to contribute new features or help fix any errors, please fork this repository and submit a pull request. We welcome contributions of all kinds, including bug fixes, documentation improvements, and new features.
+
 
 

--- a/apps/server/src/endpoints/pips/estimates.endpoint.ts
+++ b/apps/server/src/endpoints/pips/estimates.endpoint.ts
@@ -76,7 +76,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: '0000_0_0',
 					stopHeadsign: 'Olá :)',
-					stopId: '', // Deprecated
+					stopId: '000000',
+					stopSequence: -1,
 					timetabledArrivalTime: '23:59:59',
 					timetabledDepartureTime: '23:59:59',
 				},
@@ -94,7 +95,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: '0000_0_0',
 					stopHeadsign: 'Olá :)',
-					stopId: '', // Deprecated
+					stopId: '000000',
+					stopSequence: -1,
 					timetabledArrivalTime: '23:59:59',
 					timetabledDepartureTime: '23:59:59',
 				},
@@ -125,7 +127,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: '0000_0_0',
 					stopHeadsign: 'Sem estimativas. Consulte site para +info.',
-					stopId: '', // Deprecated
+					stopId: '000001',
+					stopSequence: -1,
 					timetabledArrivalTime: '23:59:59',
 					timetabledDepartureTime: '23:59:59',
 				},
@@ -156,7 +159,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: '0000_0_0',
 					stopHeadsign: 'Paragem desativada.',
-					stopId: '', // Deprecated
+					stopId: '000002', // Ensures that stopId is always an integer | id #999999 is taken by an actual stop so this was the next logical id
+					stopSequence: -1,
 					timetabledArrivalTime: '23:59:59',
 					timetabledDepartureTime: '23:59:59',
 				},
@@ -174,7 +178,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: '0000_0_0',
 					stopHeadsign: 'Painel inativo.',
-					stopId: '', // Deprecated
+					stopId: '000002', // Ensures that stopId is always an integer | id #999999 is taken by an actual stop so this was the next logical id
+					stopSequence: -1,
 					timetabledArrivalTime: '23:59:59',
 					timetabledDepartureTime: '23:59:59',
 				},
@@ -283,7 +288,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: estimate.patternId,
 					stopHeadsign: estimate.tripHeadsign,
-					stopId: '', // Deprecated
+					stopId: estimate.stopId,
+					stopSequence: estimate.stopSequence,
 					timetabledArrivalTime: estimate.stopArrivalEta || estimate.stopDepartureEta,
 					timetabledDepartureTime: estimate.stopArrivalEta || estimate.stopDepartureEta,
 				};
@@ -304,7 +310,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: estimate.patternId,
 					stopHeadsign: estimate.tripHeadsign,
-					stopId: '', // Deprecated
+					stopId: estimate.stopId,
+					stopSequence: estimate.stopSequence,
 					timetabledArrivalTime: estimate.stopArrivalEta || estimate.stopDepartureEta,
 					timetabledDepartureTime: estimate.stopArrivalEta || estimate.stopDepartureEta,
 				};
@@ -325,7 +332,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 					operatorId: '', // Deprecated
 					patternId: estimate.patternId,
 					stopHeadsign: estimate.tripHeadsign,
-					stopId: '', // Deprecated
+					stopId: estimate.stopId,
+					stopSequence: estimate.stopSequence,
 					timetabledArrivalTime: estimate.stopScheduledArrivalTime || estimate.stopScheduledDepartuteTime,
 					timetabledDepartureTime: estimate.stopScheduledArrivalTime || estimate.stopScheduledDepartuteTime,
 				};
@@ -355,7 +363,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 				operatorId: '', // Deprecated
 				patternId: '0000_0_0',
 				stopHeadsign: 'Sem estimativas em tempo real.',
-				stopId: '', // Deprecated
+				stopId: '',
+				stopSequence: -1,
 				timetabledArrivalTime: '23:59:59',
 				timetabledDepartureTime: '23:59:59',
 			},
@@ -373,7 +382,8 @@ FASTIFY.server.post<RequestSchema>('/pips/estimates', async (request, reply) => 
 				operatorId: '', // Deprecated
 				patternId: '0000_0_1',
 				stopHeadsign: 'Consulte o site para +info.',
-				stopId: '', // Deprecated
+				stopId: '',
+				stopSequence: -1,
 				timetabledArrivalTime: '23:59:59',
 				timetabledDepartureTime: '23:59:59',
 			},


### PR DESCRIPTION
(Re)Added the stopId and added stopSequence to the PIP estimates endpoint.
stopId was marked as deprecated, however, this property is useful on multi-stop requests as it makes it possible to identify the stop corresponding to a given estimate.

An example use case where these properties would come in handy is, for example, fetching all estimates for a given terminal and displaying all of the estimates on a single web page WHILST identifying the stop (P1, P2...) of each estimate.